### PR TITLE
Updated implementation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,22 @@
+root: true
+env:
+  es6: true
+  node: true
+extends: 'eslint:recommended'
+globals: 
+  atom: true
+rules:
+  indent:
+    - error
+    - 2
+  linebreak-style:
+    - error
+    - unix
+  quotes:
+    - error
+    - single
+  semi:
+    - error
+    - always
+  no-console:
+    - warn

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,23 +3,14 @@ var provider = require('./provider');
 
 module.exports = {
   config: {
-    featuresPath: {
+    stepDefinitionGlob: {
       type: 'string',
-      title: 'Features Path',
-      default: '/features',
-      description: 'This is the relative path (from your project root) to your projects features directory.'
-    },
-    stepDefinitionPath: {
-      type: 'string',
-      title: 'Step Defintions Path',
-      default: '/step_definitions',
-      description: 'This is the relative path (from your project root) to your projects step_definition directory.'
+      title: 'Step Definitions Pattern',
+      default: '**/features/step_definitions/**/*.js',
+      description: 'Pattern matching the files with step definitions in them'
     }
   },
-  activate: function() {
-    return provider.load();
-  },
   getProvider: function() {
-    return provider
+    return provider;
   }
 };

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,115 +1,53 @@
 'use babel';
-var fs = require('fs');
-var path = require('path');
 
-const FEATURES_PATH_CONFIG_KEY = 'cucumber-autocomplete-multipath.featuresPath';
-const STEP_DEFINITION_PATH_CONFIG_KEY = 'cucumber-autocomplete-multipath.stepDefinitionPath';
+const STEP_DEFINITION_GLOB_CONFIG_KEY = 'cucumber-autocomplete-multipath.stepDefinitionGlob';
 const CUCUMBER_STEP_DEF_PATTERN = /(Given|And|When|Then)\(\/\^(.*?)\$/g;
-const CUCUMBER_KEYWORDS_PATTERN = /(Given|And|When|Then)(.*)/g;
-const PROPERTY_PREFIX_PATTERN = /(?:^|\[|\(|,|=|:|\s)\s*((?:And|Given|Then|When)\s(?:[a-zA-Z]+\.?){0,2})$/;
-//Arbitary maxium depth of directories to search. There just to stop infinite loops due to symlink.
-const MAX_DEPTH = 100;
+const GROUP_CAPTURE = /([^\\]?)(\(.*?(?:[^\\])\))/g;
 
-const search = (path, pattern, depth = 0) => {
-  //Give up if the depth is over max, in case there is a recursive directory simlink in the stack somewhere.
-  if(depth > MAX_DEPTH) return [];
-  //TODO: Convert to Atom's file system APIs
-  const files = fs.readdirSync(path);
-  const features = files.filter(file => {
-    return pattern.test(file) && !fs.lstatSync(`${path}/${file}`).isDirectory();
-  });
-  const dirs = files.filter(file => fs.lstatSync(`${path}/${file}`).isDirectory());
-  const featurePaths = features.map(feature => `${path}/${feature}`);
-  const childFeaturePaths = dirs.reduce( (childFeatures, dir) => {
-    const featuresFromDir = search(`${path}/${dir}`, pattern, depth++);
-    return [...childFeatures, ...featuresFromDir];
-  }, []);
-  const allFeatures = [...featurePaths, ...childFeaturePaths];
-  return allFeatures;
+function makeSuggestion(match) {
+  
+  try {
+    CUCUMBER_STEP_DEF_PATTERN.lastIndex = 0;
+    var subgroups = CUCUMBER_STEP_DEF_PATTERN.exec(match.lineText);
+    
+    var paramCount = 0;
+    var snippet = subgroups[2].replace(GROUP_CAPTURE, (match, p1, p2) => {
+      return `${p1}\${${++paramCount}:${p2}}`;
+    });
+    
+    return {
+      snippet: snippet
+    };
+  }
+  catch(error) {
+    console.error(error);
+    console.error(match);
+  }
+  
 }
 
 module.exports = {
   selector: '.source.feature, .feature',
   filterSuggestions: true,
-  load: function() {},
-  getSuggestions: function({bufferPosition, editor}) {
+  
+  getSuggestions: function( { editor } ) {
 
-    // Disable the plugin if project hasn't been saved
-    if (!atom.project.rootDirectories[0]) {
-      return false;
-    }
-
-    let file = editor.getText();
-    let line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition]);
-    return this.getCompletions(line, file);
-  },
-  getCompletions: function(line, file) {
-    if (!this.matchCucumberKeyword(line)) return [];
-    let results = [];
-
-    try {
-      let stats = fs.lstatSync(`${this.rootDirectory()}${this.stepDefinitionsDirectory()}`)
-      if(stats.isDirectory()) {
-        return this.scanStepDefinitionsDir(results);
-      } else {
-        return this.scanFeaturesDir(results)
-      }
-    } catch (e) {
-      return this.scanFeaturesDir(results)
-    }
-  },
-  scanStepDefinitionsDir: function(results = []) {
-    //TODO: first search step definitions for your file
-    const searchPath = `${this.rootDirectory()}${this.stepDefinitionsDirectory()}`;
-    const allStepPaths = this.searchForPattern(searchPath, /.*/);
-    allStepPaths.forEach( stepDefinitionPath => {
-      let stepDefinitionFile = fs.readFileSync(stepDefinitionPath, 'utf8');
-      while((myRegexArray = CUCUMBER_STEP_DEF_PATTERN.exec(stepDefinitionFile)) != null) {
-        results.push({"snippet":this.replacedCucumberRegex(myRegexArray[2])});
-      }
-    });
-
-    return results
-  },
-  scanFeaturesDir: function(results = []) {
-    try {
-      const searchPath = `${this.rootDirectory()}${this.featuresDirectory()}`;
-      const allFeaturePaths = this.searchForPattern(searchPath, /\.feature$/);2
-
-      allFeaturePaths.forEach( featurePath => {
-        let data = fs.readFileSync(featurePath, 'utf8');
-        while((myRegexArray = CUCUMBER_KEYWORDS_PATTERN.exec(data)) != null) {
-          results.push({"text":myRegexArray[2].replace(/^\s+|\s+$/g, "")});
+    return new Promise(function(resolve) {
+      
+      var pathGlob = [atom.config.get(STEP_DEFINITION_GLOB_CONFIG_KEY)];
+      var projectPath = atom.project.relativizePath(editor.getPath())[0];
+      var suggestions = [];
+      atom.workspace.scan(CUCUMBER_STEP_DEF_PATTERN, { paths: pathGlob }, function(match) {
+        if(match.filePath.startsWith(projectPath)) {
+          match.matches.map(hit => {
+            let suggestion = makeSuggestion(hit);
+            if(suggestion) suggestions.push(suggestion);
+          });
         }
-      })
-    } catch (err) {
-      atom.notifications.addWarning(`cucumber-autocomplete: Cannot find features directory at 
-          ${this.rootDirectory()}${this.featuresDirectory()}. Please update your setting to point to the location of your features directory.`)
-    }
-
-    return results
+      }).then(() => {
+        suggestions.sort((a, b) => { return a.snippet.localeCompare(b.snippet); });
+        resolve(suggestions);
+      });
+    });
   },
-  matchCucumberKeyword: function(line) {
-    return PROPERTY_PREFIX_PATTERN.exec(line) != null;
-  },
-  rootDirectory: function() {
-    return atom.project.rootDirectories[0].path;
-  },
-  featuresDirectory: function() {
-    return atom.config.get(FEATURES_PATH_CONFIG_KEY);
-  },
-  stepDefinitionsDirectory: function() {
-    return atom.config.get(STEP_DEFINITION_PATH_CONFIG_KEY);
-  },
- // stepDefintionsDirectory: function(path=)
-  replacedCucumberRegex: function(step) {
-    //TODO: figure out how to loop through if there are multiple matches
-    //      eg: 1:numberArgument, 2:numberArgument
-    step = step.replace(/^\s+|\s+$/g, "");
-    step = step.replace(/\(\\d\+\)/g, "${1:numberArgument}");
-    return step.replace(/\(\.\*\?\)/g, "${1:textArgument}")
-  },
-  searchForPattern: function(path, pattern){
-    return search(path, pattern);
-  }
 };

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,7 +1,7 @@
 'use babel';
 
 const STEP_DEFINITION_GLOB_CONFIG_KEY = 'cucumber-autocomplete-multipath.stepDefinitionGlob';
-const CUCUMBER_STEP_DEF_PATTERN = /(Given|And|When|Then)\(\/\^(.*?)\$/g;
+const CUCUMBER_STEP_DEF_PATTERN = /(Given|And|When|Then)\((?:'(.*?)'|\/\^(.*?)\$)/g;
 const GROUP_CAPTURE = /([^\\]?)(\(.*?(?:[^\\])\))/g;
 
 function makeSuggestion(match) {
@@ -11,9 +11,13 @@ function makeSuggestion(match) {
     var subgroups = CUCUMBER_STEP_DEF_PATTERN.exec(match.lineText);
     
     var paramCount = 0;
-    var snippet = subgroups[2].replace(GROUP_CAPTURE, (match, p1, p2) => {
-      return `${p1}\${${++paramCount}:${p2}}`;
-    });
+    if(subgroups[3]) {
+      var snippet = subgroups[3].replace(GROUP_CAPTURE, (match, p1, p2) => {
+        return `${p1}\${${++paramCount}:${p2}}`;
+      });
+    } else {
+      snippet = subgroups[2];
+    }
     
     return {
       snippet: snippet

--- a/spec/features/step_definitions/sample_steps.js
+++ b/spec/features/step_definitions/sample_steps.js
@@ -1,1 +1,2 @@
-Given(/^a sample step file$
+Given(/^a sample step file$/, () => {});
+When('I use a literal string', () => {});


### PR DESCRIPTION
The primary thing I've done here is replace the file system traversal code in the original implementation with the function that the Atom api provides : `workspace.scan`. 

* Replaced file traversal code with `workspace.scan`
* Changed config of folders to a single glob
* Implemented the multiple-group matching for params
  * Still not perfect, doesn't cope with nested groups.. might work OK with non-matching groups
* Also implemented matching for literal string step matchers (single quoted only... maybe should do doubles too)